### PR TITLE
[ENHANCEMENT] Add error/warning css and functionality

### DIFF
--- a/src/components/fw-input/fw-input.css
+++ b/src/components/fw-input/fw-input.css
@@ -57,3 +57,17 @@
   border-radius: 2px;
   background-color: #FFFFFF;
 }
+
+.warning-input {
+  color: var(--sunrise);
+  border: 1px solid var(--sunrise);
+  border-radius: 2px;
+  background-color: rgba(var(--sunrise), 0.5);
+}
+
+.error-input {
+  color: var(--persimmon);
+  border: 1px solid var(--persimmon);
+  border-radius: 2px;
+  background-color: rgba(var(--persimmon), 0.5);
+}

--- a/src/components/fw-input/fw-input.tsx
+++ b/src/components/fw-input/fw-input.tsx
@@ -10,12 +10,24 @@ export class FwInput {
   @Prop() placeholder: string;
   @Prop() required: boolean;
   @Prop() stateText: string;
+  @Prop() state: string;
 
   render() {
     return <div class="input">
       <div class='label'>{this.title}{this.required?<span class="required">*</span>:''} </div>
-      <input type="text" class="input-box" placeholder={this.placeholder}></input>
-      <div class="stateText">{this.stateText}</div>
+      <input type="text" class={getCssClassName("input-box", this.state)} placeholder={this.placeholder}></input>
+      <div class={getCssClassName("stateText", this.state)}>{this.stateText}</div>
     </div>;
+  }
+}
+
+const getCssClassName = (baseClass:string, state:string) => {
+  switch (state) {
+    case 'warning':
+      return `${baseClass} warning-input`;
+    case 'error':
+      return `${baseClass} error-input`;
+    default:
+      return baseClass;
   }
 }


### PR DESCRIPTION
## Summary
Adds error and warning views on the UI for the input field and label. 

Fixes #4 

## Work Accomplished 
* [x] Added new property, `state`, to `fw-input.tsx`
* [x] Added function to generate CSS class name for both the input field and label
* [x] Added new classes in CSS for both warnings and errors based on specifications 

## Other Information
Name for contribution section: [atrievel](https://github.com/atrievel)